### PR TITLE
Move db(PDO) connection in generic function file

### DIFF
--- a/inc/db.php
+++ b/inc/db.php
@@ -1,7 +1,0 @@
-<?php
-
-
-$pdo = new PDO('mysql:dbname=test;host=localhost', 'root', 'root');
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-$pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_OBJ);
-

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -60,7 +60,9 @@ function reconnect_from_cookie()
 
     if (isset($_COOKIE['remember']) && !isset($_SESSION['auth'])) {
 
-        require_once 'db.php';
+        $pdo = new PDO('mysql:dbname=test;host=localhost', 'root', 'root');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_OBJ);
 
         if (!isset($pdo)) {
 


### PR DESCRIPTION
The database connection was made in a separate file but since it's only called 1 time, in the generic function file, it made more sense to move it directly inside it.